### PR TITLE
Fix CLI entry metadata and GUI import order

### DIFF
--- a/multi_inst/cli/__main__.py
+++ b/multi_inst/cli/__main__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+"""Console script entry point forwarding to :mod:`multi_inst.cli.diag`."""
+
+from .diag import main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience execution
+    raise SystemExit(main())

--- a/multi_inst/core/parsers.py
+++ b/multi_inst/core/parsers.py
@@ -7,6 +7,16 @@ from typing import Dict, List
 from .msp import hexlify, le_i16, le_i32, le_u16, le_u32
 
 
+def _voltage_from_raw(value_raw: int) -> Dict[str, object]:
+    if value_raw <= 255:
+        voltage = round(value_raw / 10.0, 3)
+        unit = "V(0.1)"
+    else:
+        voltage = round(value_raw / 100.0, 3)
+        unit = "V(0.01)"
+    return {"voltage_V": voltage, "unit": unit}
+
+
 def parse_status(data: bytes) -> Dict[str, object]:
     out: Dict[str, object] = {"raw": hexlify(data)}
     if len(data) >= 2:
@@ -34,7 +44,7 @@ def _decode_sensors(mask: int) -> List[str]:
 
 
 def parse_attitude(data: bytes) -> Dict[str, float]:
-    out: Dict[str, float] = {}
+    out: Dict[str, float] = {"raw": hexlify(data)}
     if len(data) >= 2:
         out["roll_deg"] = round(le_i16(data[0:2]) / 10.0, 1)
     if len(data) >= 4:
@@ -70,7 +80,7 @@ def parse_analog(data: bytes) -> Dict[str, object]:
 
 def parse_rc(data: bytes) -> Dict[str, object]:
     channels = [le_u16(data[i : i + 2]) for i in range(0, len(data), 2) if i + 2 <= len(data)]
-    out: Dict[str, object] = {"channels": channels, "count": len(channels)}
+    out: Dict[str, object] = {"raw": hexlify(data), "channels": channels, "count": len(channels)}
     if channels:
         out["min"] = min(channels)
         out["max"] = max(channels)
@@ -79,72 +89,146 @@ def parse_rc(data: bytes) -> Dict[str, object]:
 
 def parse_motors(data: bytes) -> Dict[str, object]:
     motors = [le_u16(data[i : i + 2]) for i in range(0, len(data), 2) if i + 2 <= len(data)]
-    return {"motors": motors}
+    return {"raw": hexlify(data), "motors": motors}
 
 
 def parse_voltage_meters(data: bytes) -> Dict[str, object]:
     out: Dict[str, object] = {"raw": hexlify(data), "meters": []}
     if not data:
+        out["invalid"] = True
+        out["error"] = "missing count"
         return out
     count = data[0]
-    meters = []
-    idx = 1
-    while idx + 3 <= len(data):
-        meter_id = data[idx]
-        value_raw = le_u16(data[idx + 1 : idx + 3])
-        idx += 3
-        meter = {"id": meter_id, "value_raw": value_raw}
-        if value_raw <= 255:
-            meter["voltage_V"] = round(value_raw / 10.0, 3)
-            meter["unit"] = "V(0.1)"
-        else:
-            meter["voltage_V"] = round(value_raw / 100.0, 3)
-            meter["unit"] = "V(0.01)"
-        meters.append(meter)
+    payload = data[1:]
     out["count_declared"] = count
-    out["meters"] = meters
+    if count == 0:
+        if payload:
+            out["invalid"] = True
+            out["error"] = "unexpected payload for zero count"
+        return out
+    if len(payload) == count * 3:
+        meters = []
+        idx = 0
+        while idx + 3 <= len(payload):
+            meter_id = payload[idx]
+            value_raw = le_u16(payload[idx + 1 : idx + 3])
+            idx += 3
+            entry = {"id": meter_id, "value_raw": value_raw}
+            entry.update(_voltage_from_raw(value_raw))
+            meters.append(entry)
+        out["meters"] = meters
+        return out
+    if len(payload) == count * 2:
+        meters = []
+        idx = 0
+        while idx + 2 <= len(payload):
+            value_raw = le_u16(payload[idx : idx + 2])
+            idx += 2
+            entry = {"index": len(meters), "value_raw": value_raw}
+            entry.update(_voltage_from_raw(value_raw))
+            meters.append(entry)
+        out["meters"] = meters
+        out["format"] = "values_only"
+        return out
+    out["invalid"] = True
+    out["error"] = "payload length mismatch"
+    out["payload_len"] = len(data)
     return out
 
 
 def parse_current_meters(data: bytes) -> Dict[str, object]:
     out: Dict[str, object] = {"raw": hexlify(data), "meters": []}
     if not data:
+        out["invalid"] = True
+        out["error"] = "missing count"
         return out
     count = data[0]
-    meters = []
-    idx = 1
-    while idx + 3 <= len(data):
-        meter_id = data[idx]
-        raw = le_i16(data[idx + 1 : idx + 3])
-        idx += 3
-        meters.append({"id": meter_id, "amps_A": round(raw / 100.0, 3), "unit": "A(0.01)"})
-    if idx < len(data):
-        # Fallback for i32 payloads (milliamp)
-        idx = 1
-        meters = []
-        while idx + 5 <= len(data):
-            meter_id = data[idx]
-            raw32 = le_i32(data[idx + 1 : idx + 5])
-            idx += 5
-            meters.append({"id": meter_id, "amps_A": round(raw32 / 1000.0, 3), "unit": "A(1mA)"})
+    payload = data[1:]
     out["count_declared"] = count
-    out["meters"] = meters
+    if count == 0:
+        if payload:
+            out["invalid"] = True
+            out["error"] = "unexpected payload for zero count"
+        return out
+    if len(payload) == count * 3:
+        meters = []
+        idx = 0
+        while idx + 3 <= len(payload):
+            meter_id = payload[idx]
+            raw = le_i16(payload[idx + 1 : idx + 3])
+            idx += 3
+            meters.append(
+                {
+                    "id": meter_id,
+                    "value_raw": raw,
+                    "amps_A": round(raw / 100.0, 3),
+                    "unit": "A(0.01)",
+                }
+            )
+        out["meters"] = meters
+        out["format"] = "id_i16"
+        return out
+    if len(payload) == count * 5:
+        meters = []
+        idx = 0
+        while idx + 5 <= len(payload):
+            meter_id = payload[idx]
+            raw32 = le_i32(payload[idx + 1 : idx + 5])
+            idx += 5
+            meters.append(
+                {
+                    "id": meter_id,
+                    "value_raw": raw32,
+                    "amps_A": round(raw32 / 1000.0, 3),
+                    "unit": "A(1mA)",
+                }
+            )
+        out["meters"] = meters
+        out["format"] = "id_i32"
+        return out
+    if len(payload) == count * 2:
+        meters = []
+        idx = 0
+        while idx + 2 <= len(payload):
+            raw = le_i16(payload[idx : idx + 2])
+            idx += 2
+            meters.append(
+                {
+                    "index": len(meters),
+                    "value_raw": raw,
+                    "amps_A": round(raw / 100.0, 3),
+                    "unit": "A(0.01)",
+                }
+            )
+        out["meters"] = meters
+        out["format"] = "values_only"
+        return out
+    out["invalid"] = True
+    out["error"] = "payload length mismatch"
+    out["payload_len"] = len(data)
     return out
 
 
 def parse_battery_state(data: bytes) -> Dict[str, object]:
     out: Dict[str, object] = {"raw": hexlify(data)}
-    if len(data) >= 7:
-        connected = bool(data[0])
-        voltage = le_u16(data[1:3]) / 100.0
-        mAh_used = le_u32(data[3:7])
-        out.update(
-            {
-                "connected": connected,
-                "voltage_V": round(voltage, 3),
-                "mAh_used": mAh_used,
-            }
-        )
-        if len(data) >= 9:
-            out["amps_A"] = round(le_i16(data[7:9]) / 100.0, 3)
+    if len(data) < 7:
+        out["invalid"] = True
+        out["error"] = "payload too short"
+        return out
+    if len(data) not in (7, 9):
+        out["invalid"] = True
+        out["error"] = "unexpected payload length"
+        return out
+    connected = bool(data[0])
+    voltage = le_u16(data[1:3]) / 100.0
+    mAh_used = le_u32(data[3:7])
+    out.update(
+        {
+            "connected": connected,
+            "voltage_V": round(voltage, 3),
+            "mAh_used": mAh_used,
+        }
+    )
+    if len(data) >= 9:
+        out["amps_A"] = round(le_i16(data[7:9]) / 100.0, 3)
     return out

--- a/multi_inst/gui/__init__.py
+++ b/multi_inst/gui/__init__.py
@@ -1,0 +1,3 @@
+"""GUI package for the Multi Inst toolkit."""
+
+__all__ = []

--- a/multi_inst/gui/app.py
+++ b/multi_inst/gui/app.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""PySide6 powered real-time dashboard for the Multi Inst toolkit."""
+
+import argparse
+import sys
+from typing import Iterable, List
+
+from PySide6 import QtWidgets
+
+from multi_inst.core.diagnostics import handshake
+from multi_inst.core.msp import MSPClient
+from multi_inst.io.serial_manager import list_candidate_ports
+
+from .data_models import DeviceIdentity
+from .data_sources import LiveSerialSource, build_simulated_sources
+from .device_manager import DeviceManager
+from .main_window import MainWindow
+
+try:  # pragma: no cover - optional dependency for GUI usage only
+    import serial  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    serial = None  # type: ignore[assignment]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Multi Inst GUI")
+    parser.add_argument(
+        "--sim",
+        action="store_true",
+        help="Run the GUI in simulator mode (no hardware required).",
+    )
+    parser.add_argument(
+        "--ports",
+        nargs="*",
+        help="Serial ports to monitor (defaults to auto discovery)",
+    )
+    parser.add_argument("--baud", type=int, default=1_000_000, help="Serial baud rate")
+    parser.add_argument("--loop-hz", type=float, default=30.0, help="Target polling frequency")
+    parser.add_argument(
+        "--sim-count",
+        type=int,
+        default=3,
+        help="Number of simulated devices when running with --sim",
+    )
+    return parser
+
+
+def _build_live_sources(ports: Iterable[str], baud: int, loop_hz: float) -> List[LiveSerialSource]:
+    if serial is None:
+        raise RuntimeError("pyserial is required for live telemetry mode")
+    sources: List[LiveSerialSource] = []
+    for port in ports:
+        identity = _probe_identity(port, baud)
+        sources.append(
+            LiveSerialSource(
+                identity,
+                port=port,
+                baud=baud,
+                target_hz=loop_hz,
+            )
+        )
+    return sources
+
+
+def _probe_identity(port: str, baud: int) -> DeviceIdentity:
+    if serial is None:
+        return DeviceIdentity(port=port, uid=port)
+    try:
+        with serial.Serial(port, baudrate=baud, timeout=0.3) as handle:
+            client = MSPClient(handle, inter_command_gap=0.01, retries=2)
+            client.wake()
+            info = handshake(client)
+    except Exception:  # noqa: BLE001 - handshake best effort
+        return DeviceIdentity(port=port, uid=port)
+    uid = str(info.get("uid") or info.get("board_uid") or port)
+    return DeviceIdentity(
+        port=port,
+        uid=uid,
+        variant=info.get("fc_variant"),
+        version=info.get("fc_version"),
+        board=info.get("board_id"),
+    )
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.sim:
+        sources = build_simulated_sources(args.sim_count)
+    else:
+        ports = args.ports or list_candidate_ports()
+        if not ports:
+            parser.error("no candidate serial ports discovered; use --sim for demo mode")
+        sources = _build_live_sources(ports, args.baud, args.loop_hz)
+
+    app = QtWidgets.QApplication(sys.argv or ["multi-inst-gui"])
+    manager = DeviceManager(sources)
+    window = MainWindow(manager)
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/multi_inst/gui/data_models.py
+++ b/multi_inst/gui/data_models.py
@@ -1,0 +1,50 @@
+"""Shared data models for the real-time GUI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass(slots=True)
+class DeviceIdentity:
+    """Static metadata about a flight controller device."""
+
+    port: str
+    uid: str
+    variant: str | None = None
+    version: str | None = None
+    board: str | None = None
+
+
+@dataclass(slots=True)
+class TelemetryFrame:
+    """Snapshot of MSP telemetry returned by the polling workers."""
+
+    timestamp: float
+    status: Dict[str, object] = field(default_factory=dict)
+    attitude: Dict[str, object] = field(default_factory=dict)
+    altitude: Dict[str, object] = field(default_factory=dict)
+    analog: Dict[str, object] = field(default_factory=dict)
+    rc: Dict[str, object] = field(default_factory=dict)
+    motors: Dict[str, object] = field(default_factory=dict)
+    voltage_meters: List[Dict[str, object]] = field(default_factory=list)
+    current_meters: List[Dict[str, object]] = field(default_factory=list)
+    battery_state: Dict[str, object] = field(default_factory=dict)
+    raw_imu: Dict[str, object] = field(default_factory=dict)
+    raw_packets: Dict[str, str] = field(default_factory=dict)
+
+    def value(self, path: str, default: Optional[float] = None) -> Optional[float]:
+        """Convenience helper to pull scalar values from nested dictionaries."""
+
+        namespace, _, key = path.partition(".")
+        if not namespace or not key:
+            return default
+        payload = getattr(self, namespace, None)
+        if not isinstance(payload, dict):
+            return default
+        value = payload.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+        return default
+

--- a/multi_inst/gui/data_sources.py
+++ b/multi_inst/gui/data_sources.py
@@ -1,0 +1,247 @@
+"""Data source abstractions for the GUI."""
+
+from __future__ import annotations
+
+import math
+import queue
+import random
+import threading
+import time
+from typing import Dict, Iterable, List, Optional
+
+try:  # pragma: no cover - optional dependency for GUI usage only
+    import serial  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    serial = None  # type: ignore[assignment]
+
+from multi_inst.core.commands import MSPCommand
+from multi_inst.core.msp import MSPClient, MSPChecksumError, MSPTimeoutError, hexlify, le_i16
+from multi_inst.core import parsers
+
+from .data_models import DeviceIdentity, TelemetryFrame
+
+
+class TelemetryQueue(queue.Queue[TelemetryFrame]):
+    """Simple typed queue with a helper to fetch the latest value."""
+
+    def pop_latest(self) -> Optional[TelemetryFrame]:
+        latest: Optional[TelemetryFrame] = None
+        try:
+            while True:
+                latest = self.get_nowait()
+        except queue.Empty:
+            pass
+        return latest
+
+
+class DeviceSource:
+    """Base class for telemetry sources."""
+
+    def __init__(self, identity: DeviceIdentity, *, target_hz: float) -> None:
+        self.identity = identity
+        self.queue = TelemetryQueue(maxsize=20)
+        self.target_hz = target_hz
+
+    def start(self) -> None:  # pragma: no cover - runtime behaviour
+        raise NotImplementedError
+
+    def stop(self) -> None:  # pragma: no cover - runtime behaviour
+        raise NotImplementedError
+
+
+class SimulatedSource(DeviceSource):
+    """Deterministic sine/cosine generator for GUI demos."""
+
+    def __init__(self, identity: DeviceIdentity, *, target_hz: float = 30.0) -> None:
+        super().__init__(identity, target_hz=target_hz)
+        self.queue = TelemetryQueue(maxsize=10)
+        self._thread: Optional[threading.Thread] = None
+        self._running = threading.Event()
+        self._phase = random.random() * math.pi
+
+    def start(self) -> None:  # pragma: no cover - runtime behaviour
+        if self._thread and self._thread.is_alive():
+            return
+        self._running.set()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:  # pragma: no cover - runtime behaviour
+        self._running.clear()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+    def _run(self) -> None:  # pragma: no cover - runtime behaviour
+        next_tick = time.time()
+        while self._running.is_set():
+            now = time.time()
+            dt = now - next_tick
+            if dt >= 0:
+                self.queue.put(self._generate_frame(now))
+                next_tick = now + 1.0 / max(1.0, self.target_hz)
+            time.sleep(0.002)
+
+    def _generate_frame(self, timestamp: float) -> TelemetryFrame:
+        t = timestamp + self._phase
+        roll = math.sin(t) * 5.0
+        pitch = math.cos(t * 0.7) * 4.0
+        yaw = math.sin(t * 0.5) * 180
+        hz = 400 + math.sin(t * 1.8) * 20
+        vbat = 15.5 + math.sin(t * 0.2) * 0.3
+        amps = 10 + math.sin(t * 0.4) * 2.5
+        mAh = 1200 + (timestamp % 600) * 5
+        raw_imu = {
+            "ax": math.sin(t * 1.5) * 512,
+            "ay": math.cos(t * 1.1) * 512,
+            "az": 1.0 * 512,
+            "gx": math.sin(t * 2.5) * 1000,
+            "gy": math.cos(t * 2.2) * 1000,
+            "gz": math.sin(t * 0.8) * 1000,
+        }
+        return TelemetryFrame(
+            timestamp=timestamp,
+            status={"cycleTime_us": int(1_000_000 / hz), "i2c_errors": 0},
+            attitude={"roll_deg": roll, "pitch_deg": pitch, "yaw_deg": yaw},
+            altitude={"estimated_altitude_m": math.sin(t * 0.3) * 1.5},
+            analog={"vbat_V": vbat, "amperage_A": amps, "mAh_drawn": mAh},
+            rc={"channels": [1500 + math.sin(t) * 200 for _ in range(8)]},
+            motors={"throttle": 1500 + math.sin(t * 1.2) * 200},
+            voltage_meters=[{"id": 0, "voltage_V": vbat}],
+            current_meters=[{"id": 0, "current_A": amps}],
+            battery_state={"cell_count": 4, "mah_drawn": mAh, "capacity_mah": 1800},
+            raw_imu=raw_imu,
+            raw_packets={}
+        )
+
+
+class LiveSerialSource(DeviceSource):
+    """Poll telemetry from a live MSP device using :class:`MSPClient`."""
+
+    POLL_COMMANDS: Iterable[tuple[MSPCommand, str]] = (
+        (MSPCommand.MSP_STATUS, "status"),
+        (MSPCommand.MSP_ATTITUDE, "attitude"),
+        (MSPCommand.MSP_ALTITUDE, "altitude"),
+        (MSPCommand.MSP_ANALOG, "analog"),
+        (MSPCommand.MSP_RC, "rc"),
+        (MSPCommand.MSP_MOTOR, "motors"),
+        (MSPCommand.MSP_VOLTAGE_METERS, "voltage_meters"),
+        (MSPCommand.MSP_CURRENT_METERS, "current_meters"),
+        (MSPCommand.MSP_BATTERY_STATE, "battery_state"),
+        (MSPCommand.MSP_RAW_IMU, "raw_imu"),
+    )
+
+    def __init__(
+        self,
+        identity: DeviceIdentity,
+        *,
+        port: str,
+        baud: int = 1_000_000,
+        target_hz: float = 30.0,
+        timeout: float = 0.15,
+    ) -> None:
+        super().__init__(identity, target_hz=target_hz)
+        self.queue = TelemetryQueue(maxsize=20)
+        self._port = port
+        self._baud = baud
+        self._timeout = timeout
+        self._thread: Optional[threading.Thread] = None
+        self._running = threading.Event()
+        self._client: Optional[MSPClient] = None
+
+    def start(self) -> None:  # pragma: no cover - runtime behaviour
+        if serial is None:
+            raise RuntimeError("pyserial is required for live telemetry")
+        if self._thread and self._thread.is_alive():
+            return
+        self._running.set()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:  # pragma: no cover - runtime behaviour
+        self._running.clear()
+        if self._thread:
+            self._thread.join(timeout=2.0)
+        if self._client:
+            try:
+                self._client.close()
+            except Exception:  # noqa: BLE001 - best effort shutdown
+                pass
+            self._client = None
+
+    # The heavy lifting happens in a thread to keep the Qt loop responsive.
+    def _run(self) -> None:  # pragma: no cover - runtime behaviour
+        assert serial is not None
+        while self._running.is_set():
+            try:
+                with serial.Serial(self._port, baudrate=self._baud, timeout=self._timeout) as handle:
+                    client = MSPClient(handle, inter_command_gap=0.01, retries=2)
+                    client.wake()
+                    self._client = client
+                    self._poll_loop(client)
+            except serial.SerialException:
+                time.sleep(1.0)
+            finally:
+                self._client = None
+
+    def _poll_loop(self, client: MSPClient) -> None:  # pragma: no cover - runtime behaviour
+        interval = 1.0 / max(self.target_hz, 1.0)
+        next_tick = time.time()
+        while self._running.is_set():
+            now = time.time()
+            if now >= next_tick:
+                frame = self._collect_frame(client, now)
+                if frame:
+                    self.queue.put(frame)
+                next_tick = now + interval
+            time.sleep(0.002)
+
+    def _collect_frame(self, client: MSPClient, timestamp: float) -> Optional[TelemetryFrame]:
+        payloads: Dict[str, object] = {}
+        raw_packets: Dict[str, str] = {}
+        for command, attr in self.POLL_COMMANDS:
+            try:
+                payload = client.request(command, timeout=self._timeout)
+            except (MSPTimeoutError, MSPChecksumError):
+                continue
+            if payload is None:
+                continue
+            raw_packets[attr] = hexlify(payload)
+            parser = getattr(parsers, f"parse_{attr}", None)
+            if callable(parser):
+                parsed = parser(payload)
+            elif attr == "raw_imu":
+                parsed = self._parse_raw_imu(payload)
+            else:
+                parsed = {"raw": payload}
+            payloads[attr] = parsed
+        if not payloads:
+            return None
+        return TelemetryFrame(timestamp=timestamp, raw_packets=raw_packets, **payloads)
+
+    @staticmethod
+    def _parse_raw_imu(payload: bytes) -> Dict[str, float]:
+        if len(payload) < 18:
+            return {}
+        return {
+            "ax": le_i16(payload[0:2]),
+            "ay": le_i16(payload[2:4]),
+            "az": le_i16(payload[4:6]),
+            "gx": le_i16(payload[6:8]),
+            "gy": le_i16(payload[8:10]),
+            "gz": le_i16(payload[10:12]),
+        }
+
+
+def build_simulated_sources(count: int = 2) -> List[SimulatedSource]:
+    sources: List[SimulatedSource] = []
+    for idx in range(count):
+        identity = DeviceIdentity(
+            port=f"SIM{idx}",
+            uid=f"SIM-UID-{idx:03d}",
+            variant="SIMU",
+            version="1.0.0",
+            board="SIMBOARD",
+        )
+        sources.append(SimulatedSource(identity))
+    return sources
+

--- a/multi_inst/gui/device_manager.py
+++ b/multi_inst/gui/device_manager.py
@@ -1,0 +1,74 @@
+"""Qt integration for telemetry sources."""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from typing import Deque, Dict, Iterable, List, Optional
+
+from PySide6 import QtCore
+
+from .data_models import DeviceIdentity, TelemetryFrame
+from .data_sources import DeviceSource
+
+
+class DeviceManager(QtCore.QObject):
+    """Bridge between background telemetry workers and Qt widgets."""
+
+    device_added = QtCore.Signal(DeviceIdentity)
+    device_removed = QtCore.Signal(str)
+    telemetry_updated = QtCore.Signal(str, TelemetryFrame)
+
+    def __init__(self, sources: Iterable[DeviceSource], *, history_secs: float = 30.0) -> None:
+        super().__init__()
+        self._sources: Dict[str, DeviceSource] = {}
+        self._history: Dict[str, Deque[TelemetryFrame]] = {}
+        self._history_secs = history_secs
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(int(1000 / 30))
+        self._timer.timeout.connect(self._drain_sources)  # type: ignore[arg-type]
+        for source in sources:
+            self.add_source(source)
+
+    def add_source(self, source: DeviceSource) -> None:
+        port = source.identity.port
+        self._sources[port] = source
+        self._history[port] = deque()
+        self.device_added.emit(source.identity)
+        source.start()
+        if not self._timer.isActive():
+            self._timer.start()
+
+    def remove_source(self, port: str) -> None:
+        source = self._sources.pop(port, None)
+        if source is None:
+            return
+        source.stop()
+        self._history.pop(port, None)
+        self.device_removed.emit(port)
+        if not self._sources:
+            self._timer.stop()
+
+    def histories(self, port: str) -> List[TelemetryFrame]:
+        history = self._history.get(port, deque())
+        return list(history)
+
+    def latest(self, port: str) -> Optional[TelemetryFrame]:
+        history = self._history.get(port)
+        if not history:
+            return None
+        return history[-1]
+
+    def _drain_sources(self) -> None:
+        now = time.time()
+        cutoff = now - self._history_secs
+        for port, source in list(self._sources.items()):
+            frame = source.queue.pop_latest()
+            if not frame:
+                continue
+            history = self._history.setdefault(port, deque())
+            history.append(frame)
+            while history and history[0].timestamp < cutoff:
+                history.popleft()
+            self.telemetry_updated.emit(port, frame)
+

--- a/multi_inst/gui/main_window.py
+++ b/multi_inst/gui/main_window.py
@@ -1,0 +1,97 @@
+"""Main application window for the Multi Inst GUI."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from PySide6 import QtCore, QtWidgets
+
+from .data_models import DeviceIdentity, TelemetryFrame
+from .device_manager import DeviceManager
+from .views import DashboardView, DeviceDetailsView
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self, manager: DeviceManager, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Multi Inst – Flight Controller Monitor")
+        self.resize(1400, 800)
+        self._manager = manager
+        self._selected_port: Optional[str] = None
+        self._identities: Dict[str, DeviceIdentity] = {}
+
+        toolbar = self.addToolBar("Controls")
+        toolbar.setMovable(False)
+        self._start_action = toolbar.addAction("Start")
+        self._stop_action = toolbar.addAction("Stop")
+        toolbar.addSeparator()
+        toolbar.addWidget(QtWidgets.QLabel("Profile:"))
+        self._profile = QtWidgets.QComboBox()
+        self._profile.addItems(["usb_stand", "field_strict"])
+        toolbar.addWidget(self._profile)
+        self._status_label = QtWidgets.QLabel("Idle")
+        toolbar.addWidget(self._status_label)
+
+        splitter = QtWidgets.QSplitter()
+        splitter.setOrientation(QtCore.Qt.Horizontal)
+        self._dashboard = DashboardView()
+        self._details = DeviceDetailsView()
+        splitter.addWidget(self._dashboard)
+        splitter.addWidget(self._details)
+        splitter.setStretchFactor(1, 1)
+        self.setCentralWidget(splitter)
+
+        self._dashboard.device_selected.connect(self._select_device)  # type: ignore[arg-type]
+        manager.device_added.connect(self._on_device_added)  # type: ignore[arg-type]
+        manager.device_removed.connect(self._on_device_removed)
+        manager.telemetry_updated.connect(self._on_telemetry)  # type: ignore[arg-type]
+
+        self._start_action.triggered.connect(self._resume)  # type: ignore[arg-type]
+        self._stop_action.triggered.connect(self._pause)  # type: ignore[arg-type]
+        self._profile.currentTextChanged.connect(self._on_profile_changed)  # type: ignore[arg-type]
+        self._paused = False
+        self.statusBar().showMessage("Ready")
+
+    def _resume(self) -> None:
+        self._paused = False
+        self._status_label.setText("Live")
+        self.statusBar().showMessage("Live telemetry")
+
+    def _pause(self) -> None:
+        self._paused = True
+        self._status_label.setText("Paused")
+        self.statusBar().showMessage("Paused – telemetry frozen")
+
+    def _on_profile_changed(self, profile: str) -> None:
+        self.statusBar().showMessage(f"Profile selected: {profile}")
+
+    def _select_device(self, port: str) -> None:
+        self._selected_port = port
+        identity = self._identities.get(port)
+        if identity:
+            self._details.set_device(identity)
+        history = self._manager.histories(port)
+        if history:
+            self._details.update_frame(history[-1], history)
+
+    def _on_device_added(self, identity: DeviceIdentity) -> None:
+        self._identities[identity.port] = identity
+        self._dashboard.add_device(identity)
+        if self._selected_port is None:
+            self._select_device(identity.port)
+
+    def _on_device_removed(self, port: str) -> None:
+        self._dashboard.remove_device(port)
+        self._identities.pop(port, None)
+        if self._selected_port == port:
+            self._selected_port = None
+            self._details.set_device(DeviceIdentity(port="—", uid="No device"))
+
+    def _on_telemetry(self, port: str, frame: TelemetryFrame) -> None:
+        if self._paused:
+            return
+        self._dashboard.update_frame(port, frame, self._manager.histories(port))
+        if port == self._selected_port:
+            history = self._manager.histories(port)
+            self._details.update_frame(frame, history)
+

--- a/multi_inst/gui/views/__init__.py
+++ b/multi_inst/gui/views/__init__.py
@@ -1,0 +1,6 @@
+"""View widgets for the Multi Inst GUI."""
+
+from .dashboard import DashboardView
+from .device_details import DeviceDetailsView
+
+__all__ = ["DashboardView", "DeviceDetailsView"]

--- a/multi_inst/gui/views/dashboard.py
+++ b/multi_inst/gui/views/dashboard.py
@@ -1,0 +1,138 @@
+"""Dashboard view with device tiles and sparklines."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+from PySide6 import QtCore, QtGui, QtWidgets
+import pyqtgraph as pg
+
+from ..data_models import DeviceIdentity, TelemetryFrame
+
+
+class DeviceCardWidget(QtWidgets.QFrame):
+    clicked = QtCore.Signal(str)
+
+    def __init__(self, identity: DeviceIdentity, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.identity = identity
+        self.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        self.setObjectName("device-card")
+        self.setMinimumWidth(280)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        header = QtWidgets.QHBoxLayout()
+        self._title = QtWidgets.QLabel(f"{identity.uid}")
+        self._title.setStyleSheet("font-weight: bold; font-size: 16px;")
+        header.addWidget(self._title)
+        header.addStretch(1)
+        self._status_indicator = QtWidgets.QLabel("●")
+        self._status_indicator.setStyleSheet("color: #0f0; font-size: 18px;")
+        header.addWidget(self._status_indicator)
+        layout.addLayout(header)
+
+        info_grid = QtWidgets.QFormLayout()
+        self._variant = QtWidgets.QLabel(identity.variant or "—")
+        self._version = QtWidgets.QLabel(identity.version or "—")
+        self._board = QtWidgets.QLabel(identity.board or "—")
+        info_grid.addRow("Variant", self._variant)
+        info_grid.addRow("Version", self._version)
+        info_grid.addRow("Board", self._board)
+        layout.addLayout(info_grid)
+
+        self._spark_cycle = _Sparkline("Loop Hz", color="#55acee")
+        self._spark_vbat = _Sparkline("VBat", color="#f39c12")
+        self._spark_amps = _Sparkline("Amps", color="#e74c3c")
+        layout.addWidget(self._spark_cycle)
+        layout.addWidget(self._spark_vbat)
+        layout.addWidget(self._spark_amps)
+
+        layout.addStretch(1)
+        self.setCursor(QtCore.Qt.PointingHandCursor)
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent) -> None:  # pragma: no cover - GUI event
+        if event.button() == QtCore.Qt.LeftButton:
+            self.clicked.emit(self.identity.port)
+        super().mousePressEvent(event)
+
+    def update_identity(self, identity: DeviceIdentity) -> None:
+        self.identity = identity
+        self._title.setText(identity.uid)
+        self._variant.setText(identity.variant or "—")
+        self._version.setText(identity.version or "—")
+        self._board.setText(identity.board or "—")
+
+    def update_frame(self, frame: TelemetryFrame, history: Iterable[TelemetryFrame]) -> None:
+        loop_hz = frame.value("status.cycleTime_us")
+        hz = 1_000_000 / loop_hz if loop_hz else None
+        vbat = frame.value("analog.vbat_V")
+        amps = frame.value("analog.amperage_A")
+        self._status_indicator.setStyleSheet(
+            "color: #0f0; font-size: 18px;" if frame.status else "color: #f00; font-size: 18px;"
+        )
+        self._spark_cycle.append(hz)
+        self._spark_vbat.append(vbat)
+        self._spark_amps.append(amps)
+
+
+class _Sparkline(QtWidgets.QWidget):
+    def __init__(self, title: str, *, color: str, history: int = 120, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self._history: List[Optional[float]] = []
+        self._capacity = history
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        title_label = QtWidgets.QLabel(title)
+        title_label.setStyleSheet("font-weight: bold;")
+        layout.addWidget(title_label)
+        self._plot = pg.PlotWidget(background="transparent")
+        self._plot.setFixedHeight(80)
+        self._plot.hideAxis("left")
+        self._plot.hideAxis("bottom")
+        self._curve = self._plot.plot(pen=pg.mkPen(color=color, width=2))
+        layout.addWidget(self._plot)
+
+    def append(self, value: Optional[float]) -> None:
+        if value is None:
+            return
+        self._history.append(value)
+        if len(self._history) > self._capacity:
+            self._history = self._history[-self._capacity :]
+        self._curve.setData(self._history)
+
+
+class DashboardView(QtWidgets.QScrollArea):
+    """Scrollable grid of :class:`DeviceCardWidget` instances."""
+
+    device_selected = QtCore.Signal(str)
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWidgetResizable(True)
+        container = QtWidgets.QWidget()
+        self._grid = QtWidgets.QGridLayout(container)
+        self._grid.setSpacing(12)
+        self._cards: Dict[str, DeviceCardWidget] = {}
+        self.setWidget(container)
+
+    def add_device(self, identity: DeviceIdentity) -> None:
+        card = DeviceCardWidget(identity)
+        card.clicked.connect(self.device_selected)  # type: ignore[arg-type]
+        row = len(self._cards) // 2
+        col = len(self._cards) % 2
+        self._grid.addWidget(card, row, col)
+        self._cards[identity.port] = card
+
+    def remove_device(self, port: str) -> None:
+        card = self._cards.pop(port, None)
+        if not card:
+            return
+        card.setParent(None)
+        card.deleteLater()
+
+    def update_frame(self, port: str, frame: TelemetryFrame, history: Iterable[TelemetryFrame]) -> None:
+        card = self._cards.get(port)
+        if not card:
+            return
+        card.update_frame(frame, history)
+

--- a/multi_inst/gui/views/device_details.py
+++ b/multi_inst/gui/views/device_details.py
@@ -1,0 +1,274 @@
+"""Device detail view with live charts."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+from PySide6 import QtCore, QtWidgets
+import pyqtgraph as pg
+
+from ..data_models import DeviceIdentity, TelemetryFrame
+
+
+def _stddev(values: List[float]) -> float:
+    if not values:
+        return 0.0
+    mean = sum(values) / len(values)
+    variance = sum((value - mean) ** 2 for value in values) / len(values)
+    return variance ** 0.5
+
+
+def _histogram(values: List[float], bins: int = 20) -> tuple[List[float], List[float]]:
+    if not values:
+        return [], []
+    vmin = min(values)
+    vmax = max(values)
+    if vmin == vmax:
+        return [len(values)], [vmin, vmax + 1]
+    step = (vmax - vmin) / max(1, bins)
+    edges = [vmin + i * step for i in range(bins + 1)]
+    counts = [0.0 for _ in range(bins)]
+    for value in values:
+        idx = int((value - vmin) / step)
+        if idx >= bins:
+            idx = bins - 1
+        counts[idx] += 1
+    return counts, edges
+
+
+class DeviceDetailsView(QtWidgets.QWidget):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+        self._header = QtWidgets.QLabel("Select a device on the dashboard")
+        self._header.setStyleSheet("font-size: 16px; font-weight: bold;")
+        layout.addWidget(self._header)
+        self._tabs = QtWidgets.QTabWidget()
+        layout.addWidget(self._tabs, 1)
+
+        self._overview = _OverviewTab()
+        self._imu = _ImuTab()
+        self._loop = _LoopTab()
+        self._power = _PowerTab()
+        self._raw = _RawTab()
+
+        self._tabs.addTab(self._overview, "Overview")
+        self._tabs.addTab(self._imu, "IMU")
+        self._tabs.addTab(self._loop, "Loop")
+        self._tabs.addTab(self._power, "Power")
+        self._tabs.addTab(self._raw, "Raw")
+
+    def set_device(self, identity: DeviceIdentity) -> None:
+        self._header.setText(
+            f"{identity.uid} — {identity.variant or '—'} {identity.version or ''} ({identity.port})"
+        )
+        self._overview.reset()
+        self._imu.reset()
+        self._loop.reset()
+        self._power.reset()
+        self._raw.reset()
+
+    def update_frame(self, frame: TelemetryFrame, history: Iterable[TelemetryFrame]) -> None:
+        frames = list(history)
+        self._overview.update_frame(frame, frames)
+        self._imu.update_history(frames)
+        self._loop.update_history(frames)
+        self._power.update_frame(frame)
+        self._raw.update_frame(frame)
+
+
+class _OverviewTab(QtWidgets.QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QtWidgets.QFormLayout(self)
+        self._hz = QtWidgets.QLabel("—")
+        self._gyro = QtWidgets.QLabel("—")
+        self._tilt = QtWidgets.QLabel("—")
+        layout.addRow("Loop Hz", self._hz)
+        layout.addRow("Gyro σ", self._gyro)
+        layout.addRow("Tilt", self._tilt)
+
+    def reset(self) -> None:
+        self._hz.setText("—")
+        self._gyro.setText("—")
+        self._tilt.setText("—")
+
+    def update_frame(self, frame: TelemetryFrame, history: List[TelemetryFrame]) -> None:
+        loop = frame.value("status.cycleTime_us")
+        hz = 1_000_000 / loop if loop else None
+        if hz:
+            self._hz.setText(f"{hz:.1f} Hz")
+        gx, gy, gz = [], [], []
+        for sample in history[-200:]:
+            imu = sample.raw_imu
+            if not isinstance(imu, dict):
+                continue
+            gx.append(imu.get("gx", 0))
+            gy.append(imu.get("gy", 0))
+            gz.append(imu.get("gz", 0))
+        if gx:
+            self._gyro.setText(
+                ", ".join(
+                    f"{_stddev(series):.1f}"
+                    for series in (gx, gy, gz)
+                )
+            )
+        else:
+            self._gyro.setText("—")
+        attitude = frame.attitude
+        roll = attitude.get("roll_deg")
+        pitch = attitude.get("pitch_deg")
+        if isinstance(roll, (int, float)) and isinstance(pitch, (int, float)):
+            self._tilt.setText(f"roll {roll:.1f}° | pitch {pitch:.1f}°")
+        else:
+            self._tilt.setText("—")
+
+
+class _ImuTab(QtWidgets.QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QtWidgets.QVBoxLayout(self)
+        self._plot = pg.PlotWidget(title="Gyro (°/s)")
+        self._plot.addLegend()
+        self._plot.setYRange(-500, 500)
+        self._gx = self._plot.plot(pen=pg.mkPen("#3498db", width=2), name="gx")
+        self._gy = self._plot.plot(pen=pg.mkPen("#2ecc71", width=2), name="gy")
+        self._gz = self._plot.plot(pen=pg.mkPen("#e74c3c", width=2), name="gz")
+        layout.addWidget(self._plot, 1)
+
+        self._acc_plot = pg.PlotWidget(title="Accelerometer norm (g)")
+        self._acc_plot.setYRange(0, 3)
+        self._acc_curve = self._acc_plot.plot(pen=pg.mkPen("#9b59b6", width=2))
+        layout.addWidget(self._acc_plot, 1)
+
+    def reset(self) -> None:
+        self._gx.clear()
+        self._gy.clear()
+        self._gz.clear()
+        self._acc_curve.clear()
+
+    def update_history(self, history: List[TelemetryFrame]) -> None:
+        gx, gy, gz, acc = [], [], [], []
+        for frame in history[-600:]:
+            imu = frame.raw_imu
+            if not isinstance(imu, dict):
+                continue
+            gx.append(imu.get("gx", 0))
+            gy.append(imu.get("gy", 0))
+            gz.append(imu.get("gz", 0))
+            ax = imu.get("ax", 0) / 512.0
+            ay = imu.get("ay", 0) / 512.0
+            az = imu.get("az", 0) / 512.0
+            acc.append((ax**2 + ay**2 + az**2) ** 0.5)
+        self._gx.setData(gx)
+        self._gy.setData(gy)
+        self._gz.setData(gz)
+        self._acc_curve.setData(acc)
+
+
+class _LoopTab(QtWidgets.QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QtWidgets.QVBoxLayout(self)
+        self._loop_plot = pg.PlotWidget(title="Cycle time (µs)")
+        self._loop_curve = self._loop_plot.plot(pen=pg.mkPen("#1abc9c", width=2))
+        layout.addWidget(self._loop_plot, 1)
+
+        self._hist_plot = pg.PlotWidget(title="Cycle histogram")
+        self._hist_curve = self._hist_plot.plot(stepMode=True, pen=pg.mkPen("#34495e", width=2))
+        layout.addWidget(self._hist_plot, 1)
+
+    def reset(self) -> None:
+        self._loop_curve.clear()
+        self._hist_curve.clear()
+
+    def update_history(self, history: List[TelemetryFrame]) -> None:
+        cycles: List[float] = []
+        for frame in history[-600:]:
+            cycle = frame.value("status.cycleTime_us")
+            if cycle:
+                cycles.append(cycle)
+        if cycles:
+            self._loop_curve.setData(cycles)
+            y, x = _histogram(cycles)
+            step_x: List[float] = []
+            step_y: List[float] = []
+            for idx, height in enumerate(y):
+                left = x[idx]
+                right = x[idx + 1]
+                step_x.extend([left, right])
+                step_y.extend([height, height])
+            self._hist_curve.setData(step_x, step_y)
+        else:
+            self._hist_curve.clear()
+
+
+class _PowerTab(QtWidgets.QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QtWidgets.QFormLayout(self)
+        self._vbat = QtWidgets.QLabel("—")
+        self._amps = QtWidgets.QLabel("—")
+        self._mah = QtWidgets.QLabel("—")
+        layout.addRow("Voltage", self._vbat)
+        layout.addRow("Current", self._amps)
+        layout.addRow("Consumed", self._mah)
+
+        self._meters = QtWidgets.QTableWidget(0, 4)
+        self._meters.setHorizontalHeaderLabels(["ID", "Voltage (V)", "Current (A)", "Valid"])
+        self._meters.horizontalHeader().setStretchLastSection(True)
+        layout.addRow(QtWidgets.QLabel("Meters"), self._meters)
+
+    def reset(self) -> None:
+        self._vbat.setText("—")
+        self._amps.setText("—")
+        self._mah.setText("—")
+        self._meters.setRowCount(0)
+
+    def update_frame(self, frame: TelemetryFrame) -> None:
+        vbat = frame.value("analog.vbat_V")
+        amps = frame.value("analog.amperage_A")
+        mah = frame.value("analog.mAh_drawn")
+        if vbat is not None:
+            self._vbat.setText(f"{vbat:.2f} V")
+        if amps is not None:
+            self._amps.setText(f"{amps:.2f} A")
+        if mah is not None:
+            self._mah.setText(f"{mah:.0f} mAh")
+
+        meter_rows: List[Dict[str, object]] = []
+        by_id: Dict[object, Dict[str, object]] = {}
+        for meter in frame.voltage_meters:
+            ident = meter.get("id", len(by_id))
+            entry = dict(meter)
+            entry.setdefault("current_A", "—")
+            by_id[ident] = entry
+        for meter in frame.current_meters:
+            ident = meter.get("id", len(by_id))
+            entry = by_id.setdefault(ident, {"id": ident})
+            entry.update(meter)
+        meter_rows = list(by_id.values())
+        self._meters.setRowCount(len(meter_rows))
+        for row, meter in enumerate(meter_rows):
+            self._meters.setItem(row, 0, QtWidgets.QTableWidgetItem(str(meter.get("id", "—"))))
+            self._meters.setItem(row, 1, QtWidgets.QTableWidgetItem(str(meter.get("voltage_V", "—"))))
+            self._meters.setItem(row, 2, QtWidgets.QTableWidgetItem(str(meter.get("current_A", "—"))))
+            invalid = meter.get("invalid")
+            self._meters.setItem(row, 3, QtWidgets.QTableWidgetItem("no" if not invalid else "yes"))
+
+
+class _RawTab(QtWidgets.QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QtWidgets.QVBoxLayout(self)
+        self._list = QtWidgets.QListWidget()
+        layout.addWidget(self._list)
+
+    def reset(self) -> None:
+        self._list.clear()
+
+    def update_frame(self, frame: TelemetryFrame) -> None:
+        self._list.clear()
+        for key, value in frame.raw_packets.items():
+            self._list.addItem(f"{key}: {value}")
+

--- a/multi_inst/io/serial_manager.py
+++ b/multi_inst/io/serial_manager.py
@@ -6,7 +6,10 @@ import glob
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Iterable, List, Optional, Sequence, Tuple
 
-import serial
+try:  # pragma: no cover - optional dependency guard for unit tests
+    import serial  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - serial is required in production
+    serial = None  # type: ignore[assignment]
 
 from multi_inst.core.diagnostics import (
     DiagConfig,
@@ -58,6 +61,8 @@ class SerialManager:
         return results, summaries
 
     def _process_port(self, port: str, config: DiagConfig) -> Tuple[dict, dict]:
+        if serial is None:
+            raise RuntimeError("pyserial is not installed")
         try:
             serial_port = serial.Serial(port, baudrate=config.baud, timeout=0.3)
         except serial.SerialException as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,14 @@ dev = [
     "ruff>=0.4.0",
     "pytest>=7.4.0",
 ]
+gui = [
+    "PySide6>=6.6",
+    "pyqtgraph>=0.13",
+]
 
 [project.scripts]
-multi-inst = "cli.diag:main"
+"multi-inst" = "multi_inst.cli.__main__:main"
+"multi-inst-gui" = "multi_inst.gui.app:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from multi_inst.core import parsers
+
+
+def test_parse_status_includes_raw_and_units():
+    payload = bytes([0x10, 0x27, 0x02, 0x00, 0x01, 0x00, 0xAA, 0x55, 0x00, 0x00])
+    result = parsers.parse_status(payload)
+    assert result["raw"] == payload.hex()
+    assert result["cycleTime_us"] == 10000
+    assert result["i2c_errors"] == 2
+    assert "ACC" in result["sensors"]
+
+
+def test_parse_attitude_scales_degrees():
+    payload = bytes([0x64, 0x00, 0x9C, 0xFF, 0x20, 0x03])
+    result = parsers.parse_attitude(payload)
+    assert result["raw"] == payload.hex()
+    assert result["roll_deg"] == pytest.approx(10.0)
+    assert result["pitch_deg"] == pytest.approx(-10.0)
+    assert result["yaw_deg"] == 800.0
+
+
+def test_parse_altitude_converts_to_meters():
+    payload = (1000).to_bytes(4, "little", signed=True) + (50).to_bytes(2, "little", signed=True)
+    payload += (1500).to_bytes(4, "little", signed=True)
+    result = parsers.parse_altitude(payload)
+    assert result["raw"] == payload.hex()
+    assert result["alt_m"] == 10.0
+    assert result["vario_cmps"] == 50
+    assert result["baro_alt_m"] == 15.0
+
+
+def test_parse_analog_units():
+    payload = bytes([50, 0x10, 0x00, 0x34, 0x12, 0xF4, 0x01])
+    result = parsers.parse_analog(payload)
+    assert result["raw"] == payload.hex()
+    assert result["vbat_V"] == pytest.approx(5.0)
+    assert result["mAh_used"] == 0x0010
+    assert result["amps_A"] == pytest.approx(5.0)
+
+
+def test_parse_voltage_meters_id_u16():
+    payload = bytes([2, 1, 200, 0, 2, 0x20, 0x03])
+    result = parsers.parse_voltage_meters(payload)
+    assert "invalid" not in result
+    assert result["count_declared"] == 2
+    assert result["meters"][0]["voltage_V"] == pytest.approx(20.0)
+    assert result["meters"][1]["voltage_V"] == pytest.approx(8.0)
+
+
+def test_parse_voltage_meters_values_only():
+    payload = bytes([2, 0x10, 0x00, 0x20, 0x03])
+    result = parsers.parse_voltage_meters(payload)
+    assert result["format"] == "values_only"
+    assert result["meters"][0]["voltage_V"] == pytest.approx(1.6)
+
+
+def test_parse_voltage_meters_invalid_length():
+    payload = bytes([1, 0x01])
+    result = parsers.parse_voltage_meters(payload)
+    assert result["invalid"] is True
+
+
+def test_parse_current_meters_formats():
+    payload_i16 = bytes([1, 5, 0xE8, 0x03])
+    result_i16 = parsers.parse_current_meters(payload_i16)
+    assert result_i16["format"] == "id_i16"
+    assert result_i16["meters"][0]["amps_A"] == pytest.approx(10.0)
+
+    payload_i32 = bytes([1, 5, 0x10, 0x27, 0x00, 0x00])
+    result_i32 = parsers.parse_current_meters(payload_i32)
+    assert result_i32["format"] == "id_i32"
+    assert result_i32["meters"][0]["amps_A"] == pytest.approx(10.0)
+
+    payload_values_only = bytes([2, 0xE8, 0x03, 0xD0, 0x07])
+    result_values = parsers.parse_current_meters(payload_values_only)
+    assert result_values["format"] == "values_only"
+    assert result_values["meters"][1]["amps_A"] == pytest.approx(20.0)
+
+
+def test_parse_current_meters_invalid():
+    payload = bytes([1, 0x01])
+    result = parsers.parse_current_meters(payload)
+    assert result["invalid"] is True
+
+
+def test_parse_battery_state_handles_short_payload():
+    payload = bytes([0x01, 0x10, 0x27])
+    result = parsers.parse_battery_state(payload)
+    assert result["raw"] == payload.hex()
+    assert result["invalid"] is True


### PR DESCRIPTION
## Summary
- quote the script names in pyproject.toml so editable installs succeed
- ensure the CLI and GUI modules place __future__ imports before other statements to avoid syntax errors at runtime

## Testing
- pip install -e .[dev]
- pytest
- multi-inst --help

------
https://chatgpt.com/codex/tasks/task_e_68d136616d888321b823df3e50d8872a